### PR TITLE
[FEAT] 이메일 인증 비동기 처리 구현

### DIFF
--- a/src/main/java/com/jobdam/jobdam_be/auth/controller/AuthController.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/controller/AuthController.java
@@ -22,7 +22,7 @@ public class AuthController {
 
 
     @GetMapping("/check-email")
-    public ResponseEntity<Map<String, Boolean>> checkEmail(@RequestBody String email) {
+    public ResponseEntity<Map<String, Boolean>> checkEmail(@RequestParam String email) {
         return authService.checkEmail(email);
     }
 

--- a/src/main/java/com/jobdam/jobdam_be/auth/dao/EmailVerificationDAO.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/dao/EmailVerificationDAO.java
@@ -1,6 +1,6 @@
 package com.jobdam.jobdam_be.auth.dao;
 
-import com.jobdam.jobdam_be.auth.mapper.VerificationMapper;
+import com.jobdam.jobdam_be.auth.mapper.EmailVerificationMapper;
 import com.jobdam.jobdam_be.auth.model.EmailVerification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class EmailVerificationDAO {
-    private final VerificationMapper verificationMapper;
+    private final EmailVerificationMapper verificationMapper;
 
     public void saveOrUpdateVerification(EmailVerification certification) {
         verificationMapper.saveOrUpdateVerification(certification);

--- a/src/main/java/com/jobdam/jobdam_be/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/exception/AuthErrorCode.java
@@ -16,7 +16,7 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_REQUEST(401, "로그인에 실패했습니다."),
     UNAUTHORIZED_REQUEST(401, "인증되지 않은 요청입니다."),
     EXPIRED_TOKEN(401, "토큰이 만료되었습니다."),
-    INVALID_TOKEN(401, "잘못된 토큰입니다."),
+    INVALID_TOKEN(401, "유효하지 않는 토큰입니다."),
     INVALID_SIGNATURE(401, "JWT 서명이 일치하지 않습니다."),
 
     EMAIL_VERIFICATION_REQUIRED(403, "이메일 인증을 먼저 진행하세요."),

--- a/src/main/java/com/jobdam/jobdam_be/auth/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/exception/CustomAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package com.jobdam.jobdam_be.auth.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jobdam.jobdam_be.global.exception.type.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
-        AuthErrorCode errorCode = UNAUTHORIZED_REQUEST;
+        ErrorCode errorCode = UNAUTHORIZED_REQUEST;
         if (authException instanceof JwtAuthException ex) {
             errorCode = ex.getErrorCode();  // errorCode 꺼내기
         }
@@ -33,7 +34,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         sendErrorResponse(response, errorCode);
     }
 
-    private void sendErrorResponse(HttpServletResponse response, AuthErrorCode errorCode) throws IOException {
+    private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
         response.setStatus(errorCode.getCode());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/jobdam/jobdam_be/auth/exception/JwtAuthException.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/exception/JwtAuthException.java
@@ -1,13 +1,14 @@
 package com.jobdam.jobdam_be.auth.exception;
 
+import com.jobdam.jobdam_be.global.exception.type.ErrorCode;
 import lombok.Getter;
 import org.springframework.security.core.AuthenticationException;
 
 @Getter
 public class JwtAuthException extends AuthenticationException {
-    private final AuthErrorCode errorCode;
+    private final ErrorCode errorCode;
 
-    public JwtAuthException(AuthErrorCode errorCode) {
+    public JwtAuthException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }

--- a/src/main/java/com/jobdam/jobdam_be/auth/filter/LoginFilter.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/filter/LoginFilter.java
@@ -93,7 +93,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         response.addCookie(refreshCookie);
 
         boolean isSaved = jwtService.saveRefreshToken(user.getId(), refresh, 86400000L);
-        if (!isSaved) request.setAttribute("exception", DB_ERROR);
+        if (!isSaved) {
+            request.setAttribute("exception", DB_ERROR);
+        }
 
 
         response.setStatus(HttpServletResponse.SC_OK);
@@ -107,7 +109,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         } else if (failed instanceof BadCredentialsException) {
             request.setAttribute("exception", INVALID_EMAIL_OR_PASSWORD);
             throw new JwtAuthException(INVALID_EMAIL_OR_PASSWORD);
-        }else {
+        } else {
             throw new JwtAuthException(UNKNOWN_ERROR);
         }
     }

--- a/src/main/java/com/jobdam/jobdam_be/auth/filter/LoginFilter.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/filter/LoginFilter.java
@@ -103,7 +103,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     //로그인 실패시 실행하는 메소드
     @Override
-    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
         if (failed instanceof JwtAuthException e) {
             throw e;
         } else if (failed instanceof BadCredentialsException) {

--- a/src/main/java/com/jobdam/jobdam_be/auth/mapper/EmailVerificationMapper.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/mapper/EmailVerificationMapper.java
@@ -4,7 +4,7 @@ import com.jobdam.jobdam_be.auth.model.EmailVerification;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
-public interface VerificationMapper {
+public interface EmailVerificationMapper {
     void saveOrUpdateVerification(EmailVerification certification);
 
     EmailVerification findByEmail(String email);

--- a/src/main/java/com/jobdam/jobdam_be/auth/provider/EmailProvider.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/provider/EmailProvider.java
@@ -3,10 +3,13 @@ package com.jobdam.jobdam_be.auth.provider;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.CompletableFuture;
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -14,35 +17,38 @@ public class EmailProvider {
 
     private final JavaMailSender javaMailSender;
 
+    @Value("${spring.mail.username}")
+    private String fromAddress;
+    @Value("${spring.mail.properties.mail.smtp.nickname}")
+    private String fromName;
     private final String SUBJECT = "[잡담 - 모의면접 매칭 서비스] 이메일 인증 메일입니다.";
 
-    // TODO: 이메일 인증 비동기 처리
     /**
      * POST /login 클라이언트가 로그인 POST 요청을 보낼 때 실행
      *
      * @param email 유저의 이메일 주소
-     * @param code 인증번호
+     * @param code  인증번호
      * @return AuthenticationManager 내부에서  UserDetailsService를 통해 검사 -> 결과에 따라 성공, 실패 메서드 호출
      */
-    public boolean sendVerificationMail(String email, String code) {
+    @Async("mailExecutor")
+    public CompletableFuture<Boolean> sendVerificationMail(String email, String code) {
         try {
             MimeMessage message = javaMailSender.createMimeMessage();
-            MimeMessageHelper messageHelper = new MimeMessageHelper(message, true);
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
 
             String htmlContent = getVerificationMessage(code);
 
             messageHelper.setTo(email);     // 대상의 이메일 주소
             messageHelper.setSubject(SUBJECT);      // 제목
             messageHelper.setText(htmlContent, true);   // 내용
+            messageHelper.setFrom(fromAddress, fromName);
 
             javaMailSender.send(message);
-
         } catch (Exception e) {
             log.error(e.getMessage(), e);
-            return false;
+            return CompletableFuture.completedFuture(false);
         }
-
-        return true;
+        return CompletableFuture.completedFuture(true);
     }
 
     private String getVerificationMessage(String code) {

--- a/src/main/java/com/jobdam/jobdam_be/config/AsyncConfig.java
+++ b/src/main/java/com/jobdam/jobdam_be/config/AsyncConfig.java
@@ -1,0 +1,36 @@
+package com.jobdam.jobdam_be.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean(name = "mailExecutor")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("MailExecutor-");
+        executor.initialize();
+        return executor;
+    }
+
+//    @Override
+//    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+//        return (e, method, params) ->
+//                log.error("Exception handler for async method '{}' threw unexpected exception itself"
+//                        , method.toGenericString(), e);
+//    }
+}

--- a/src/main/java/com/jobdam/jobdam_be/user/controller/UserController.java
+++ b/src/main/java/com/jobdam/jobdam_be/user/controller/UserController.java
@@ -15,7 +15,7 @@ public class UserController {
     private final UserService userService;
     @GetMapping("/test")
     public String test(){
-        userService.test();
+        // userService.test();
         return "test";
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,4 @@ spring.mail.username=jobdam.dev@gmail.com
 spring.mail.password=
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.nickname=Jobdam

--- a/src/main/resources/mappers/EmailVerificationMapper.xml
+++ b/src/main/resources/mappers/EmailVerificationMapper.xml
@@ -3,7 +3,7 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="com.jobdam.jobdam_be.auth.mapper.VerificationMapper">
+<mapper namespace="com.jobdam.jobdam_be.auth.mapper.EmailVerificationMapper">
 
     <insert id="saveOrUpdateVerification" parameterType="com.jobdam.jobdam_be.auth.model.EmailVerification">
         INSERT INTO email_verification (email, code, created_at)


### PR DESCRIPTION
완전한 비동기로 구현하기엔, 인증번호 발신에 실패했을 때의 처리가 불명확하기에,
하나의 쓰레드를 5초간 블로킹하는 방식으로 구현

-> 추후 스레드 고갈로 병목현상이 발생할 때 수정 예정 (WebFlux, DeferredResult?)