### PR TITLE
[REFACTOR] OAuth2 후 JWT 제공 방식 변경

### DIFF
--- a/src/main/java/com/jobdam/jobdam_be/auth/controller/AuthController.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/controller/AuthController.java
@@ -38,14 +38,15 @@ public class AuthController {
 
     @GetMapping("/verify")
     public ResponseEntity<Map<String, Boolean>> verify(@RequestParam String token) {
-        authService.verifyEmail(token);
+        Long userId = authService.verifyEmail(token);
 
-        return authService.isProfileSetup(token);
+        return authService.isProfileSetup(userId);
     }
 
     // Social 쿠키 검증 후 헤더에 토큰 제공
     @GetMapping("/oauth-redirect")
     public ResponseEntity<Map<String, Boolean>> oauthRedirect(HttpServletRequest request, HttpServletResponse response) {
+
          String token = null;
 
         for (Cookie cookie : request.getCookies()) {
@@ -54,11 +55,9 @@ public class AuthController {
             }
         }
 
-        log.info("Authorization: {}", token);
+        Long userId = authService.setLoginToken(token, response);
 
-        authService.setLoginToken(token, response);
-
-        return authService.isProfileSetup(token);
+        return authService.isProfileSetup(userId);
     }
 
     @PostMapping("/reissue")

--- a/src/main/java/com/jobdam/jobdam_be/auth/dao/TempTokenDAO.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/dao/TempTokenDAO.java
@@ -1,0 +1,24 @@
+package com.jobdam.jobdam_be.auth.dao;
+
+import com.jobdam.jobdam_be.auth.mapper.TempTokenMapper;
+import com.jobdam.jobdam_be.auth.model.OauthTempToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TempTokenDAO {
+    private final TempTokenMapper tempTokenMapper;
+
+    public void save(OauthTempToken token) {
+        tempTokenMapper.save(token);
+    }
+
+    public Long findUserIdByToken(String token) {
+        return tempTokenMapper.findUserIdByToken(token);
+    }
+
+    public void deleteByToken(String token) {
+        tempTokenMapper.deleteByToken(token);
+    }
+}

--- a/src/main/java/com/jobdam/jobdam_be/auth/mapper/TempTokenMapper.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/mapper/TempTokenMapper.java
@@ -1,0 +1,13 @@
+package com.jobdam.jobdam_be.auth.mapper;
+
+import com.jobdam.jobdam_be.auth.model.OauthTempToken;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface TempTokenMapper {
+    void save(OauthTempToken token);
+
+    Long findUserIdByToken(String token);
+
+    void deleteByToken(String token);
+}

--- a/src/main/java/com/jobdam/jobdam_be/auth/model/OauthTempToken.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/model/OauthTempToken.java
@@ -1,0 +1,24 @@
+package com.jobdam.jobdam_be.auth.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OauthTempToken {
+    private String tempToken;
+
+    private Long userId;
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime expiresAt = createdAt.plusMinutes(1);
+
+    public OauthTempToken(String uuid, Long id) {
+        tempToken = uuid;
+        userId = id;
+    }
+}

--- a/src/main/java/com/jobdam/jobdam_be/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/service/CustomOAuth2UserService.java
@@ -44,9 +44,14 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             email = responseMap.get("email");
             name = responseMap.get("name");
             profileImgUrl = responseMap.get("profile_image");
-            String fullDateStr = responseMap.get("birthyear") + "-" + responseMap.get("birthday");
-            LocalDate localDate = LocalDate.parse(fullDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-            user.setBirthday(Timestamp.valueOf(localDate.atStartOfDay()));
+
+            String birthyear = responseMap.get("birthyear");
+            String birthday = responseMap.get("birthday");
+            if (birthyear != null && birthday != null) {
+                String fullDateStr = birthyear + "-" + birthday;
+                LocalDate localDate = LocalDate.parse(fullDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                user.setBirthday(Timestamp.valueOf(localDate.atStartOfDay()));
+            }
 
         } else if (registrationId.equals("google")) {
             Map<String, Object> responseMap = oAuth2User.getAttributes();

--- a/src/main/java/com/jobdam/jobdam_be/auth/service/JwtService.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/service/JwtService.java
@@ -15,8 +15,9 @@ public class JwtService {
     private final TokenProperties tokenProperties;
     private final RefreshDAO refreshDAO;
 
-    public Cookie createAccessCookie(String token) {
+    public Cookie createTempCookie(String token) {
         Cookie cookie = new Cookie("Authorization", token);
+        cookie.setPath("/");
         cookie.setHttpOnly(true);
         cookie.setMaxAge(10 * 60);
         return cookie;

--- a/src/main/resources/mappers/tempTokenMapper.xml
+++ b/src/main/resources/mappers/tempTokenMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.jobdam.jobdam_be.auth.mapper.TempTokenMapper">
+    <insert id="save">
+        INSERT INTO temp_token (temp_token_id, user_id, created_at, expires_at)
+        VALUES (#{tempToken}, #{userId}, #{createdAt}, #{expiresAt});
+    </insert>
+    <delete id="deleteByToken">
+        DELETE FROM temp_token WHERE temp_token_id = #{token}
+    </delete>
+    <select id="findUserIdByToken" resultType="java.lang.Long">
+        SELECT user_id AS userId
+        FROM temp_token
+        WHERE temp_token_id = #{token}
+    </select>
+</mapper>


### PR DESCRIPTION
OAuth2 성공 후 서버에서 직접 리다이렉트 시 쿠키 전달 실패하는 에러 수정
-> 임시 토큰을 쿠키에 담아 제공 + redirectUrl 명시

프론트에서 redirectUrl하면 쿠키 사용 가능
이후 GET: /oauth-redirect 요청하게 되면 그때 토큰 생성 후 제공


네이버 로그인시 추가 선택 사항인 생일과 출생년도를 선택하지 않았을 시, 코드가 구동되지 않는 문제 해결