### PR TITLE
이력서 요약 및 질문 추출 AI 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     implementation 'commons-io:commons-io:2.14.0'
     implementation 'net.sourceforge.tess4j:tess4j:5.4.0'
 
+    // webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,11 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.1'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.780'
 
+    // PDF
+    implementation 'org.apache.pdfbox:pdfbox:2.0.30'
+    implementation 'commons-io:commons-io:2.14.0'
+    implementation 'net.sourceforge.tess4j:tess4j:5.4.0'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/jobdam/jobdam_be/clova/api/ClovaApiClient.java
+++ b/src/main/java/com/jobdam/jobdam_be/clova/api/ClovaApiClient.java
@@ -1,0 +1,76 @@
+package com.jobdam.jobdam_be.clova.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jobdam.jobdam_be.clova.dto.ChatRequest;
+import com.jobdam.jobdam_be.global.exception.type.CommonErrorCode;
+import com.jobdam.jobdam_be.user.exception.UserException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClovaApiClient {
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${clova.api.key}")
+    private String apiKey;
+
+    // 요약 AI 요청
+    public Mono<String> sampling(String requestId, ChatRequest request) {
+        return webClient.post()
+                .uri("testapp/v3/chat-completions/HCX-005")
+                .header("Authorization", "Bearer " + apiKey)
+                .header("X-NCP-CLOVASTUDIO-REQUEST-ID", requestId)
+                .header("Content-Type", "application/json")
+                .bodyValue(request)
+                .retrieve()
+                .bodyToFlux(String.class)
+                .doOnNext(line -> log.info("RECV LINE: {}", line))
+                .filter(line -> line.contains("\"result\""))
+                .map(this::extractSamplingContent)
+                .last();
+    }
+
+    // 질문 생성 AI 요청
+    public Mono<String> generateQuestions(String requestId, ChatRequest request) {
+        return webClient.post()
+                .uri("/testapp/v3/chat-completions/HCX-DASH-002")
+                .header("Authorization", "Bearer " + apiKey)
+                .header("X-NCP-CLOVASTUDIO-REQUEST-ID", requestId)
+                .header("Content-Type", "application/json")
+                .header("Accept", "text/event-stream")
+                .bodyValue(request)
+                .retrieve()
+                .bodyToFlux(String.class)
+                .filter(line -> !line.contains("[DONE]") && line.contains("\"message\""))
+                .map(this::extractQuestionContent)
+                .last();
+    }
+
+    // 샘플링 결과 추출
+    private String extractSamplingContent(String json) {
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            return node.path("result").path("message").path("content").asText();
+        } catch (Exception e) {
+            throw new UserException(CommonErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+
+    // 질문 생성 결과 추출
+    private String extractQuestionContent(String json) {
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            return node.path("message").path("content").asText();
+        } catch (Exception e) {
+            throw new UserException(CommonErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/src/main/java/com/jobdam/jobdam_be/clova/config/WebClientConfig.java
+++ b/src/main/java/com/jobdam/jobdam_be/clova/config/WebClientConfig.java
@@ -1,4 +1,4 @@
-package com.jobdam.jobdam_be.global.config;
+package com.jobdam.jobdam_be.clova.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/jobdam/jobdam_be/clova/dto/ChatRequest.java
+++ b/src/main/java/com/jobdam/jobdam_be/clova/dto/ChatRequest.java
@@ -1,0 +1,6 @@
+package com.jobdam.jobdam_be.clova.dto;
+
+import java.util.List;
+
+public record ChatRequest(List<Message> messages, int maxTokens) {
+}

--- a/src/main/java/com/jobdam/jobdam_be/clova/dto/Message.java
+++ b/src/main/java/com/jobdam/jobdam_be/clova/dto/Message.java
@@ -1,0 +1,4 @@
+package com.jobdam.jobdam_be.clova.dto;
+
+public record Message(String role, String content) {
+}

--- a/src/main/java/com/jobdam/jobdam_be/clova/service/ResumeAiService.java
+++ b/src/main/java/com/jobdam/jobdam_be/clova/service/ResumeAiService.java
@@ -1,0 +1,117 @@
+package com.jobdam.jobdam_be.clova.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jobdam.jobdam_be.clova.api.ClovaApiClient;
+import com.jobdam.jobdam_be.clova.dto.Message;
+import com.jobdam.jobdam_be.clova.dto.ChatRequest;
+import com.jobdam.jobdam_be.common.PDFProvider;
+import com.jobdam.jobdam_be.global.exception.type.CommonErrorCode;
+import com.jobdam.jobdam_be.interview.model.AiResumeQuestion;
+import com.jobdam.jobdam_be.interview.service.InterviewService;
+import com.jobdam.jobdam_be.user.exception.UserException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ResumeAiService {
+    private final ClovaApiClient clovaApiClient;
+    private final InterviewService interviewService;
+
+    @Value("${clova.resume.question.prompt}")
+    private String questionPrompt;
+    @Value("${clova.resume.sampling.prompt}")
+    private String samplingPrompt;
+
+    @Value("${clova.resume.sampling.id}")
+    private String samplingId;
+
+    @Value("${clova.resume.question.id}")
+    private String questionId;
+
+    private static final int MIN_TEXT_LENGTH_FOR_SAMPLING = 500;
+
+    @Async("clovaExecutor")
+    public void analyzeResumeAndPDF(MultipartFile resume, Long resumeId) {
+        String resumeText = PDFProvider.pdfToString(resume);
+
+        if (resumeText.length() < MIN_TEXT_LENGTH_FOR_SAMPLING) {
+            analyzeWithoutSampling(resumeText, resumeId);
+        } else {
+            analyzeWithSampling(resumeText, resumeId);
+        }
+    }
+
+    // 내용이 적기에 요약이 필요하지 않을 경우
+    private void analyzeWithoutSampling(String resumeText, Long resumeId) {
+        String questions = buildQuestionMono(resumeText).block();
+         saveQuestionsAsync(resumeId, questions);
+    }
+
+    // 내용이 많아 요약이 필요할 경우
+    private void analyzeWithSampling(String resumeText, Long resumeId) {
+        ChatRequest samplingRequest = new ChatRequest(
+                List.of(new Message("system", samplingPrompt), new Message("user", resumeText)),1000);
+
+        String samplingResume = clovaApiClient.sampling(samplingId, samplingRequest).block();
+        String questions = buildQuestionMono(samplingResume).block();
+        saveQuestionsAsync(resumeId, questions);
+    }
+
+    // 질문 생성
+    private Mono<String> buildQuestionMono(String inputText) {
+        ChatRequest chatRequest = new ChatRequest(
+                List.of(new Message("system", questionPrompt), new Message("user", inputText)),800);
+        return clovaApiClient.generateQuestions(questionId, chatRequest);
+    }
+
+    // 저장 요청
+    private void saveQuestionsAsync(Long resumeId, String response) {
+        try {
+            List<AiResumeQuestion> questions = extractQuestions(resumeId, response);
+            interviewService.replaceAllAiQuestions(resumeId, questions);
+        } catch (Exception e) {
+            log.error("질문 분할 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    // json 으로 받은 답변 쪼개기
+    private List<AiResumeQuestion> extractQuestions(Long resumeId, String json) throws Exception {
+        String cleanedJson = json.replaceAll("(?s)```(?:json)?\\s*|```", "").trim();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(cleanedJson);
+
+        JsonNode questionsNode = root.get("questions");
+        if (questionsNode == null || !questionsNode.isObject()) {
+            throw new UserException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        List<AiResumeQuestion> questionList = new ArrayList<>();
+
+        for (Iterator<String> it = questionsNode.fieldNames(); it.hasNext(); ) {
+            String field = it.next();
+            JsonNode arr = questionsNode.get(field);
+            if (arr.isArray()) {
+                for (JsonNode q : arr) {
+                    questionList.add(AiResumeQuestion.builder()
+                            .resumeId(resumeId)
+                            .question(q.asText())
+                            .build());
+                }
+            }
+        }
+
+        return questionList;
+    }
+}

--- a/src/main/java/com/jobdam/jobdam_be/common/PDFProvider.java
+++ b/src/main/java/com/jobdam/jobdam_be/common/PDFProvider.java
@@ -1,0 +1,31 @@
+package com.jobdam.jobdam_be.common;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PDFProvider {
+
+    public static String pdfToString(MultipartFile pdf) {
+        try (InputStream inputStream = pdf.getInputStream();
+             PDDocument document = PDDocument.load(inputStream)) {
+
+            PDFTextStripper pdfStripper = new PDFTextStripper();
+
+            return pdfStripper.getText(document);
+
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            return "텍스트 추출 실패: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/jobdam/jobdam_be/global/config/AsyncConfig.java
+++ b/src/main/java/com/jobdam/jobdam_be/global/config/AsyncConfig.java
@@ -15,14 +15,25 @@ import java.util.concurrent.Executor;
 @EnableAsync
 public class AsyncConfig extends AsyncConfigurerSupport {
 
-    @Override
     @Bean(name = "mailExecutor")
-    public Executor getAsyncExecutor() {
+    public Executor getMailAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(2);
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(10);
         executor.setThreadNamePrefix("MailExecutor-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    @Bean(name = "clovaExecutor")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("ClovaExecutor-");
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/jobdam/jobdam_be/global/config/WebClientConfig.java
+++ b/src/main/java/com/jobdam/jobdam_be/global/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package com.jobdam.jobdam_be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder.baseUrl("https://clovastudio.stream.ntruss.com")
+                .build();
+    }
+}

--- a/src/main/java/com/jobdam/jobdam_be/interview/dao/InterviewDAO.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/dao/InterviewDAO.java
@@ -1,6 +1,7 @@
 package com.jobdam.jobdam_be.interview.dao;
 
 import com.jobdam.jobdam_be.interview.mapper.InterviewMapper;
+import com.jobdam.jobdam_be.interview.model.AiResumeQuestion;
 import com.jobdam.jobdam_be.interview.model.Interview;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -19,5 +20,13 @@ public class InterviewDAO {
 
     public List<Map<String, Object>> findFeedbackByInterviewIdAndUserId(Long interviewId, Long userId) {
         return interviewMapper.findFeedbackByInterviewIdAndUserId(interviewId, userId);
+    }
+
+    public int insertAiQuestions(List<AiResumeQuestion> questions) {
+        return interviewMapper.insertAiQuestions(questions);
+    }
+
+    public void resetAiQuestion(Long resumeId) {
+        interviewMapper.resetAiQuestion(resumeId);
     }
 }

--- a/src/main/java/com/jobdam/jobdam_be/interview/mapper/InterviewMapper.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/mapper/InterviewMapper.java
@@ -1,5 +1,6 @@
 package com.jobdam.jobdam_be.interview.mapper;
 
+import com.jobdam.jobdam_be.interview.model.AiResumeQuestion;
 import com.jobdam.jobdam_be.interview.model.Interview;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -11,4 +12,8 @@ public interface InterviewMapper {
     List<Interview> findInterviewById(Long userId);
 
     List<Map<String, Object>> findFeedbackByInterviewIdAndUserId(Long interviewId, Long userId);
+
+    int insertAiQuestions(List<AiResumeQuestion> questions);
+
+    void resetAiQuestion(Long resumeId);
 }

--- a/src/main/java/com/jobdam/jobdam_be/interview/model/AiResumeQuestion.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/model/AiResumeQuestion.java
@@ -1,0 +1,15 @@
+package com.jobdam.jobdam_be.interview.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class AiResumeQuestion {
+    private Long id;
+    private Long resumeId;
+    private String question;
+}

--- a/src/main/java/com/jobdam/jobdam_be/interview/service/InterviewService.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/service/InterviewService.java
@@ -2,9 +2,11 @@ package com.jobdam.jobdam_be.interview.service;
 
 import com.jobdam.jobdam_be.interview.dao.InterviewDAO;
 import com.jobdam.jobdam_be.interview.dto.QuestionFeedbackDto;
+import com.jobdam.jobdam_be.interview.model.AiResumeQuestion;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -16,6 +18,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class InterviewService {
     private final InterviewDAO interviewDAO;
+
     public List<QuestionFeedbackDto> getFeedback(Long interviewId, Long userId) {
 
         List<Map<String, Object>> rows = interviewDAO.findFeedbackByInterviewIdAndUserId(interviewId, userId);
@@ -39,6 +42,12 @@ public class InterviewService {
         }
 
         return new ArrayList<>(grouped.values());
-
     }
+
+    @Transactional
+    public void replaceAllAiQuestions(Long resumeId, List<AiResumeQuestion> questions) {
+        interviewDAO.resetAiQuestion(resumeId);
+        int result = interviewDAO.insertAiQuestions(questions);
+    }
+
 }

--- a/src/main/java/com/jobdam/jobdam_be/user/controller/UserController.java
+++ b/src/main/java/com/jobdam/jobdam_be/user/controller/UserController.java
@@ -1,10 +1,12 @@
 package com.jobdam.jobdam_be.user.controller;
 
+import com.jobdam.jobdam_be.clova.service.ResumeAiService;
 import com.jobdam.jobdam_be.interview.model.Interview;
 import com.jobdam.jobdam_be.s3.service.S3Service;
 import com.jobdam.jobdam_be.user.dto.UserInitProfileDTO;
 import com.jobdam.jobdam_be.user.dto.UserMatchingProfileDTO;
 import com.jobdam.jobdam_be.user.dto.UserProfileDTO;
+import com.jobdam.jobdam_be.user.model.Resume;
 import com.jobdam.jobdam_be.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ import java.util.Map;
 public class UserController {
     private final UserService userService;
     private final S3Service s3Service;
+    private final ResumeAiService resumeAiService;
 
     @PostMapping("/profile")
     public ResponseEntity<String> saveProfile(@Valid @RequestPart("data") UserInitProfileDTO dto,
@@ -87,9 +90,10 @@ public class UserController {
             resumeUrl = s3Service.uploadResume(file, findImgUrl, userId);
         }
 
-        userService.savePDF(userId, resumeUrl);
         Resume resume = new Resume(null, userId, resumeUrl);
         userService.savePDF(resume);
+
+        resumeAiService.analyzeResumeAndPDF(file, resume.getResumeId());
 
         // String pdfToString = PDFProvider.pdfToString(file);
         Map<String, String> response = new HashMap<>();

--- a/src/main/java/com/jobdam/jobdam_be/user/controller/UserController.java
+++ b/src/main/java/com/jobdam/jobdam_be/user/controller/UserController.java
@@ -88,6 +88,8 @@ public class UserController {
         }
 
         userService.savePDF(userId, resumeUrl);
+        Resume resume = new Resume(null, userId, resumeUrl);
+        userService.savePDF(resume);
 
         // String pdfToString = PDFProvider.pdfToString(file);
         Map<String, String> response = new HashMap<>();

--- a/src/main/java/com/jobdam/jobdam_be/user/model/Resume.java
+++ b/src/main/java/com/jobdam/jobdam_be/user/model/Resume.java
@@ -1,16 +1,14 @@
 package com.jobdam.jobdam_be.user.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class Resume {
-    private Long id;
+    private Long resumeId;
     private Long userId;
     private String url;
 }

--- a/src/main/java/com/jobdam/jobdam_be/user/service/UserService.java
+++ b/src/main/java/com/jobdam/jobdam_be/user/service/UserService.java
@@ -95,14 +95,13 @@ public class UserService {
             throw new UserException(CommonErrorCode.INTERNAL_SERVER_ERROR, e);
         }
     }
+
     /**
      * 이력서 저장
      *
-     * @param fileUrl - 새롭게 생성된 파일 url
+     * @param resume - 새롭게 생성된 이력서 모델
      */
-    public void savePDF(Long userId, String fileUrl) {
-        Resume resume = new Resume(null, userId, fileUrl);
-
+    public void savePDF(Resume resume) {
         userDAO.saveOrUpdateResume(resume);
     }
 
@@ -130,18 +129,21 @@ public class UserService {
                 .educationStatus(dto.getEducationStatus())
                 .build();
     }
+
     //매칭시 먼저 선택할 내정보가져오기
     public UserMatchingProfileDTO.Response getMyMatchingProfile(Long userId) {
         User user = userDAO.findById(userId)
                 .orElseThrow(() -> new UserException(CommonErrorCode.USER_NOT_FOUND));
         return modelMapper.map(user, UserMatchingProfileDTO.Response.class);
     }
+
     //userJobJoin 가져오기(jobCode 말고 한글로) chat에서 사용할 줄 알았는데
     //생각해보니 UI에서 선택한거 보여줘야해서 사용 보류..
     public UserJobJoinModel getUserJobJoinModel(Long userId){
         return userDAO.findUserJobJoinById(userId)
                 .orElseThrow(() -> new UserException(CommonErrorCode.USER_NOT_FOUND));
     }
+
     //유저정보 id로 가져오기
     public User getUserById(Long userId){
         return userDAO.findById(userId)

--- a/src/main/resources/application-common.properties
+++ b/src/main/resources/application-common.properties
@@ -40,5 +40,7 @@ spring.cloud.aws.s3.bucket=${S3_BUCKET}
 spring.servlet.multipart.max-file-size=20MB
 spring.servlet.multipart.max-request-size=40MB
 
+# Ai
+clova.api.key=${CLOVA_API_KEY}
 
 logging.level.org.springframework.security=DEBUG

--- a/src/main/resources/application-common.properties
+++ b/src/main/resources/application-common.properties
@@ -42,5 +42,9 @@ spring.servlet.multipart.max-request-size=40MB
 
 # Ai
 clova.api.key=${CLOVA_API_KEY}
+clova.resume.question.prompt=${CLOVA_RESUME_QUESTION_PROMPT}
+clova.resume.question.id=${CLOVA_RESUME_QUESTION_ID}
+clova.resume.sampling.prompt=${CLOVA_RESUME_SAMPLING_PROMPT}
+clova.resume.sampling.id=${CLOVA_RESUME_SAMPLING_ID}
 
 logging.level.org.springframework.security=DEBUG

--- a/src/main/resources/mappers/interviewMapper.xml
+++ b/src/main/resources/mappers/interviewMapper.xml
@@ -13,6 +13,20 @@
         <result property="jobCode" column="job_code"/>
     </resultMap>
 
+    <insert id="insertAiQuestions">
+        INSERT INTO ai_resume_question (resume_id, question)
+        VALUES
+        <foreach collection="questions" item="q" separator=",">
+            (#{q.resumeId}, #{q.question})
+        </foreach>
+    </insert>
+
+    <delete id="resetAiQuestion">
+        DELETE
+        FROM ai_resume_question
+        WHERE resume_id = #{resumeID}
+    </delete>
+
     <select id="findInterviewById" resultMap="InterviewResultMap">
         SELECT *
         FROM interview

--- a/src/main/resources/mappers/userMapper.xml
+++ b/src/main/resources/mappers/userMapper.xml
@@ -45,11 +45,13 @@
                 #{providerId})
     </insert>
 
-    <insert id="saveOrUpdateResume">
+    <!-- useGeneratedKeys="true" DB에서 생성된 자동 증가 키 값을 가져 옴 -->
+    <!-- keyProperty="resumeId" 어느 Java 객체의 어떤 필드에 넣을지 지정 -->
+    <insert id="saveOrUpdateResume" useGeneratedKeys="true" keyProperty="resumeId">
         INSERT INTO resume (user_id, url)
         VALUES (#{userId}, #{url})
         ON DUPLICATE KEY UPDATE
-            url = #{url}
+            url = #{url}, id = LAST_INSERT_ID(id)
     </insert>
 
     <update id="updateCreatedAtByEmail">
@@ -155,23 +157,22 @@
 
     <!-- 유저정보+job정보(jobCode를 한글로 보여주기 위해) -->
     <select id="findUserJobJoinById" resultType="com.jobdam.jobdam_be.user.model.UserJobJoinModel">
-        SELECT
-        id,
-        email,
-        name,
-        birthday,
-        target_company_size AS targetCompanySize,
-        profile_img_url AS profileImgUrl,
-        user.job_code AS jobCode,
-        job_group.job_group,
-        user.job_detail_code AS jobDetailCode,
-        job_detail.job_detail,
-        experience_type AS experienceType,
-        education_level AS educationLevel,
-        education_status AS educationStatus
+        SELECT id,
+               email,
+               name,
+               birthday,
+               target_company_size  AS targetCompanySize,
+               profile_img_url      AS profileImgUrl,
+               user.job_code        AS jobCode,
+               job_group.job_group,
+               user.job_detail_code AS jobDetailCode,
+               job_detail.job_detail,
+               experience_type      AS experienceType,
+               education_level      AS educationLevel,
+               education_status     AS educationStatus
         FROM user
-        LEFT JOIN job_group ON user.job_code = job_group.job_code
-        LEFT JOIN job_detail ON user.job_detail_code = job_detail.job_detail_code
+                 LEFT JOIN job_group ON user.job_code = job_group.job_code
+                 LEFT JOIN job_detail ON user.job_detail_code = job_detail.job_detail_code
         WHERE id = #{id}
     </select>
 </mapper>


### PR DESCRIPTION
POST: /resume 요청시 pdf 텍스트 분석 후 CLOVA에 요청하여 요약 및 면접 질문을 추출함.

해당 결과에 따라 기존에 있던 질문 제거 후 삽입
- WebClient 에서는 트랜잭션이 안되기에 InterviewService 에 메서드 구현

---

 현재 사용중인 WebClient는 Webflux에 의존되지만, 클라이언트 라이브러리이기에 서버 모델과는 무관하여 사용 가능