### PR TITLE
[FIX] 유저가 S3에 저장되지 않은 파일을 보낼 경우 발생되는 문제 해결

### DIFF
--- a/src/main/java/com/jobdam/jobdam_be/s3/service/S3Service.java
+++ b/src/main/java/com/jobdam/jobdam_be/s3/service/S3Service.java
@@ -93,7 +93,11 @@ public class S3Service {
      * @return 파일 키 값
      */
     private String getFileKey(String url) {
-        return url.split(".com/")[1];
+        String[] split = url.split(".com/");
+        if(split.length < 2) {
+            return null;
+        }
+        return split[1];
     }
 
     /**


### PR DESCRIPTION
 S3가 아닌 경우 split이 정상적으로 동작되지 않기에,(https://picsum.photos/200/300) split 후 개수를 파악하여 null을 제공
 -> S3 삭제 x