### PR TITLE
[FEAT] 면접 타입별로 AI 질문 구별

### DIFF
--- a/src/main/java/com/jobdam/jobdam_be/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/jobdam/jobdam_be/auth/filter/JwtAuthenticationFilter.java
@@ -73,12 +73,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authToken);
 
         } catch (ExpiredJwtException e) {
+            log.info("JWT token expired : ", e);
             request.setAttribute("exception", EXPIRED_TOKEN);
             throw new JwtAuthException(EXPIRED_TOKEN, e);
         } catch (JwtAuthException e) {
+            log.info("JWT token invalid : ", e);
             request.setAttribute("exception", e.getErrorCode());
             throw e;
         } catch (Exception e) {
+            log.info("JWT token error : ",e);
             request.setAttribute("exception", INVALID_TOKEN);
             throw new JwtAuthException(INVALID_TOKEN, e);
 

--- a/src/main/java/com/jobdam/jobdam_be/clova/api/ClovaApiClient.java
+++ b/src/main/java/com/jobdam/jobdam_be/clova/api/ClovaApiClient.java
@@ -55,7 +55,7 @@ public class ClovaApiClient {
                 .last();
     }
 
-    // 질문 생성 AI 요청
+    // 피드백 생성 AI 요청
     public Mono<String> samplingFeedBack(String requestId, ChatRequest request) {
         return webClient.post()
                 .uri("/testapp/v3/chat-completions/HCX-DASH-002")

--- a/src/main/java/com/jobdam/jobdam_be/clova/loader/FeedbackSamplingPromptLoader.java
+++ b/src/main/java/com/jobdam/jobdam_be/clova/loader/FeedbackSamplingPromptLoader.java
@@ -25,7 +25,6 @@ public class FeedbackSamplingPromptLoader {
     public void loadPrompt() {
         try {
             feedbackSummaryPrompt = Files.readString(Paths.get(promptFile.getURI()));
-            log.info("피드백 요약 프롬프트 로드 완료: {}", feedbackSummaryPrompt);
         } catch (IOException e) {
             log.error("피드백 요약 프롬프트 파일 로드 실패:  {}", e.getMessage(), e);
             feedbackSummaryPrompt = "다음은 여러 면접관에게 받은 모의 면접 피드백 내용입니다. 피드백을 종합해 JSON 형식으로 정리해줘.\n" +

--- a/src/main/java/com/jobdam/jobdam_be/clova/loader/ResumeQuestionPromptLoader.java
+++ b/src/main/java/com/jobdam/jobdam_be/clova/loader/ResumeQuestionPromptLoader.java
@@ -25,7 +25,6 @@ public class ResumeQuestionPromptLoader {
     public void loadPrompt() {
         try {
             resumeQuestionPrompt = Files.readString(Paths.get(promptFile.getURI()));
-            log.info("자기소개서 질문 추출 프롬프트 로드 완료: {}", resumeQuestionPrompt);
         } catch (IOException e) {
             log.error("자기소개서 질문 추출 프롬프트 파일 로드 실패:  {}", e.getMessage(), e);
             resumeQuestionPrompt = "당신은 HR 면접관이자 채용 담당 역할을 수행하는 AI입니다.\n" +

--- a/src/main/java/com/jobdam/jobdam_be/clova/loader/ResumeSamplingPromptLoader.java
+++ b/src/main/java/com/jobdam/jobdam_be/clova/loader/ResumeSamplingPromptLoader.java
@@ -25,7 +25,6 @@ public class ResumeSamplingPromptLoader {
     public void loadPrompt() {
         try {
             resumeSummaryPrompt = Files.readString(Paths.get(promptFile.getURI()));
-            log.info("자기소개서 요약 프롬프트 로드 완료: {}", resumeSummaryPrompt);
         } catch (IOException e) {
             log.error("자기소개서 요약 프롬프트 파일 로드 실패:  {}", e.getMessage(), e);
             resumeSummaryPrompt = "너는 사용자의 자기소개서를 면접 질문 생성을 위한 핵심 정보로 요약하는 역할이야.\n" +

--- a/src/main/java/com/jobdam/jobdam_be/interview/controller/InterviewController.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/controller/InterviewController.java
@@ -3,7 +3,6 @@ package com.jobdam.jobdam_be.interview.controller;
 import com.jobdam.jobdam_be.interview.dto.*;
 import com.jobdam.jobdam_be.clova.service.ClovaAiService;
 import com.jobdam.jobdam_be.interview.dto.QuestionFeedbackDto;
-import com.jobdam.jobdam_be.interview.model.Interview;
 import com.jobdam.jobdam_be.interview.service.InterviewService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +12,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -91,6 +89,9 @@ public class InterviewController {
     public ResponseEntity<String> testGenerateFeedbackReportTEST() throws Exception {
         // 다른 유저들에게 받은 피드백을 String으로 변환하여 받음
         String feedbacks = interviewService.getFeedbacksForSameInterview(4L);
+
+        if(feedbacks == null)
+            return ResponseEntity.ok("피드백 리포트 생성 없음");
 
         // List로 받을 때, 0번째 인덱스에는 잘한점, 1번째 인덱스에는 개선할 점이 포함
         // 잘한점과, 개선할 점을 하나의 문자열로 받고 있음 - 요청시 수정가능

--- a/src/main/java/com/jobdam/jobdam_be/interview/dao/InterviewDAO.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/dao/InterviewDAO.java
@@ -2,9 +2,7 @@ package com.jobdam.jobdam_be.interview.dao;
 
 import com.jobdam.jobdam_be.interview.mapper.InterviewMapper;
 import com.jobdam.jobdam_be.interview.model.*;
-import com.jobdam.jobdam_be.interview.type.InterviewType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/src/main/java/com/jobdam/jobdam_be/interview/dao/InterviewDAO.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/dao/InterviewDAO.java
@@ -2,6 +2,7 @@ package com.jobdam.jobdam_be.interview.dao;
 
 import com.jobdam.jobdam_be.interview.mapper.InterviewMapper;
 import com.jobdam.jobdam_be.interview.model.*;
+import com.jobdam.jobdam_be.interview.type.InterviewType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -33,8 +34,8 @@ public class InterviewDAO {
          interviewMapper.saveInterview(interview);
     }
 
-    public void copyAiToInterviewQuestions(Long userId, Long interviewId) {
-        interviewMapper.copyAiToInterviewQuestions(userId, interviewId);
+    public void copyAiToInterviewQuestions(Long userId, Long interviewId, InterviewType interviewType) {
+        interviewMapper.copyAiToInterviewQuestions(userId, interviewId, interviewType);
     }
 
     public List<InterviewQuestion> findAllLatestQuestionsByInterviewId(Long interviewId) {

--- a/src/main/java/com/jobdam/jobdam_be/interview/mapper/InterviewMapper.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/mapper/InterviewMapper.java
@@ -20,7 +20,7 @@ public interface InterviewMapper {
 
     void saveInterview(Interview interview);
 
-    void copyAiToInterviewQuestions(Long userId, Long interviewId);
+    void copyAiToInterviewQuestions(Long userId, Long interviewId, InterviewType interviewType);
 
     List<InterviewQuestion> findAllLatestQuestionsByInterviewId(Long interviewId);
 

--- a/src/main/java/com/jobdam/jobdam_be/interview/model/AiResumeQuestion.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/model/AiResumeQuestion.java
@@ -1,5 +1,6 @@
 package com.jobdam.jobdam_be.interview.model;
 
+import com.jobdam.jobdam_be.interview.type.InterviewType;
 import lombok.*;
 
 @Getter
@@ -12,4 +13,5 @@ public class AiResumeQuestion {
     private Long id;
     private Long resumeId;
     private String question;
+    private InterviewType interviewType;
 }

--- a/src/main/java/com/jobdam/jobdam_be/interview/service/InterviewService.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/service/InterviewService.java
@@ -108,11 +108,11 @@ public class InterviewService {
                 .build();
         interviewDAO.saveInterview(interview);
 
-        if(Objects.isNull(interview.getId()))
+        if (Objects.isNull(interview.getId()))
             throw new InterviewException(InterviewErrorCode.DB_INSERT_ERROR);
 
         //Ai질문을 인터뷰질문테이블로 복사
-        interviewDAO.copyAiToInterviewQuestions(userId,interview.getId());
+        interviewDAO.copyAiToInterviewQuestions(userId, interview.getId(), interview.getInterviewType());
     }
     //화경면접 초기데이터 가져오기(이력서+ai질문들)
     public InterviewFullDataDTO.Response getInterviewFullData(Long userId) {

--- a/src/main/java/com/jobdam/jobdam_be/interview/service/InterviewService.java
+++ b/src/main/java/com/jobdam/jobdam_be/interview/service/InterviewService.java
@@ -1,6 +1,5 @@
 package com.jobdam.jobdam_be.interview.service;
 
-import com.jobdam.jobdam_be.clova.service.ClovaAiService;
 import com.jobdam.jobdam_be.interview.dao.InterviewDAO;
 import com.jobdam.jobdam_be.interview.dto.*;
 import com.jobdam.jobdam_be.interview.exception.InterviewErrorCode;
@@ -10,16 +9,12 @@ import com.jobdam.jobdam_be.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.GetMapping;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -89,6 +84,9 @@ public class InterviewService {
 
     public String getFeedbacksForSameInterview(Long interviewId) {
         List<String> feedbacks = interviewDAO.findFeedbacksForSameInterview(interviewId);
+        if (feedbacks.isEmpty()) {
+            return null;
+        }
         return feedbacks.toString();
     }
 

--- a/src/main/resources/mappers/interviewMapper.xml
+++ b/src/main/resources/mappers/interviewMapper.xml
@@ -19,11 +19,11 @@
         <result property="context" column="context"/>
     </resultMap>
 
-    <insert id="insertAiQuestions">
-        INSERT INTO ai_resume_question (resume_id, question)
+    <insert id="insertAiQuestions" parameterType="java.util.Map">
+        INSERT INTO ai_resume_question (resume_id, question, interview_type)
         VALUES
         <foreach collection="questions" item="q" separator=",">
-            (#{q.resumeId}, #{q.question})
+            (#{q.resumeId}, #{q.question}, #{q.interviewType})
         </foreach>
     </insert>
 

--- a/src/main/resources/mappers/interviewMapper.xml
+++ b/src/main/resources/mappers/interviewMapper.xml
@@ -83,7 +83,7 @@
         WHERE resume_id = (SELECT id
                            FROM resume
                            WHERE user_id = #{userId}
-        );
+        ) AND interview_type = #{interviewType};
     </insert>
 
     <select id="findOneLatestInterviewByUserId" resultMap="InterviewResultMap">


### PR DESCRIPTION
AI 질문 생성시 타입 별로 질문을 받아, DB에 질문을 저장할 때 타입도 함께 저장하도록 DB 수정

화상면접시 대상의 면접타입 별로 해당하는 질문만 받도록 변경